### PR TITLE
Update top-navigation.liquid

### DIFF
--- a/snippets/top-navigation.liquid
+++ b/snippets/top-navigation.liquid
@@ -39,7 +39,7 @@ Positioning the Bar: The top bar is built with a single nav element with a class
                 <ul class="f-dropdown dropdown" id="drop-{{ forloop.index }}">
                     {% if has_sub_menu %}
                       {% for l in linklists[child_list_handle].links %}
-                      <li class="small-12 columnds{% if forloop.first %} first{% elsif forloop.last %} last{% endif %}{% if l.active %} active{% endif %}">
+                      <li class="small-12 columns{% if forloop.first %} first{% elsif forloop.last %} last{% endif %}{% if l.active %} active{% endif %}">
                         <a class="{% if forloop.first %}first{% elsif forloop.last %}last{% endif %}" href="{{ l.url }}">{{ l.title }}</a>
                       </li>
                       {% endfor %}

--- a/snippets/top-navigation.liquid
+++ b/snippets/top-navigation.liquid
@@ -33,19 +33,19 @@ Positioning the Bar: The top bar is built with a single nav element with a class
               {% elsif link.type == 'collection_link' and link.object.all_tags.size > 0 %}
                 {% assign has_sub_categories = true %}
               {% endif %}
-              <li class="nav-item{% if forloop.first %} first{% elsif forloop.last %} last{% endif %}{% if link.active or parent_link_active %} active{% endif %}{% if has_sub_menu or has_sub_categories %} has-dropdown{% endif %}">
+              <li class="nav-item{% if forloop.first %} first{% elsif forloop.last %} last{% endif %}{% if link.active or parent_link_active %} active{% endif %}{% if has_sub_menu or has_sub_categories %} has-dropdown{% endif %}" {% if has_sub_menu or has_sub_categories %} data-dropdown="drop-{{ forloop.index}}"{% endif %}>
                 {{ link.title | link_to: link.url }}
                 {% if has_sub_menu or has_sub_categories %}
-                  <ul class="dropdown">
+                <ul class="f-dropdown dropdown" id="drop-{{ forloop.index }}">
                     {% if has_sub_menu %}
                       {% for l in linklists[child_list_handle].links %}
-                      <li class="{% if forloop.first %} first{% elsif forloop.last %} last{% endif %}{% if l.active %} active{% endif %}">
+                      <li class="small-12 columnds{% if forloop.first %} first{% elsif forloop.last %} last{% endif %}{% if l.active %} active{% endif %}">
                         <a class="{% if forloop.first %}first{% elsif forloop.last %}last{% endif %}" href="{{ l.url }}">{{ l.title }}</a>
                       </li>
                       {% endfor %}
                     {% elsif has_sub_categories %}
                       {% for tag in link.object.all_tags %}
-                      <li class="{% if forloop.first %} first{% elsif forloop.last %} last{% endif %}{% if current_tags contains tag %} active{% endif %}">
+                      <li class="small-12 columns{% if forloop.first %} first{% elsif forloop.last %} last{% endif %}{% if current_tags contains tag %} active{% endif %}">
                         <a class="{% if forloop.first %}first{% elsif forloop.last %}last{% endif %}" href="{{ link.url }}/{{ tag | handle }}">{{ tag }}</a>
                       </li>
                       {% endfor %}


### PR DESCRIPTION
This fixes a bug in the foundation 5 framework, I've added an updated dropdown.js to add to the fix..

With this update dropdowns with anchors actually work in small, medium, and large+ views, and I added support for multiple dropdowns using unique ID's, with the help of  forloop.index to generate the unique dropdown id's!